### PR TITLE
Fixing iverilog

### DIFF
--- a/iverilog/build.sh
+++ b/iverilog/build.sh
@@ -7,7 +7,7 @@ if [ x"$TRAVIS" = xtrue ]; then
 	CPU_COUNT=2
 fi
 
-export CXXFLAGS=-Wno-deprecated-declarations
+export CC_FOR_BUILD=$CC
 
 sh ./autoconf.sh
 ./configure --prefix=$PREFIX


### PR DESCRIPTION
Makes sure it always uses the conda GCC compiler.

Fixes https://github.com/SymbiFlow/conda-packages/issues/17

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>