### PR TITLE
Add zachjs-sv2v package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ env:
   - PACKAGE=icestorm
   - PACKAGE=iverilog
   - PACKAGE=verilator
+  # SystemVerilog tools
+  - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
 
 script:
   - bash $TRAVIS_BUILD_DIR/.travis/script.sh

--- a/zachjs-sv2v/build.sh
+++ b/zachjs-sv2v/build.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+set -e
+set -x
+
+make
+install -D bin/sv2v $PREFIX/bin/zachjs-sv2v

--- a/zachjs-sv2v/meta.yaml
+++ b/zachjs-sv2v/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: zachjs-sv2v
+  version: {{ GIT_FULL_HASH }}
+
+source:
+  git_url: https://github.com/zachjs/sv2v.git
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - stack
+
+test:
+  commands:
+    - zachjs-sv2v --help
+
+about:
+  home: https://github.com/zachjs/sv2v
+  license: BSD
+  license_file: LICENSE
+  summary: 'sv2v converts SystemVerilog (IEEE 1800-2017) to Verilog (IEEE 1364-2005), with an emphasis on supporting synthesizable language constructs.'


### PR DESCRIPTION
Aim of this PR is to create conda package with [sv2v](https://github.com/zachjs/sv2v) tool which will be used in SymbiFlow/sv-tests#183