### PR TITLE
Add ODIN-II package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ env:
   - PACKAGE=verilator
   # SystemVerilog tools
   - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
+  - PACKAGE=odin_II             CONDA_CHANNELS="pkgw-forge,conda-forge"
 
 script:
   - bash $TRAVIS_BUILD_DIR/.travis/script.sh

--- a/odin_II/build.sh
+++ b/odin_II/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+cd ODIN_II
+make build -j$CPU_COUNT
+install -D odin_II $PREFIX/bin/odin_II

--- a/odin_II/meta.yaml
+++ b/odin_II/meta.yaml
@@ -1,0 +1,44 @@
+package:
+  name: odin_ii
+  version: {{ GIT_FULL_HASH }}
+
+source:
+  git_url: https://github.com/verilog-to-routing/vtr-verilog-to-routing
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - bison
+    - cmake
+    - flex
+    - fontconfig
+    - ncurses
+    - pkg-config
+    - readline <8
+    - tk
+    - xorg-libice
+    - xorg-libsm
+    - xorg-libx11
+    - xorg-libxcb
+    - xorg-libxext
+    - xorg-libxft
+    - tbb
+    - tbb-devel
+    - gtk3
+
+about:
+  home: http://verilogtorouting.org/
+  license: MIT
+  license_file: LICENSE.md
+  summary: 'Odin II is used for logic synthesis and elaboration, converting a subset of the Verilog Hardware Description Language (HDL) into a BLIF netlist.'


### PR DESCRIPTION
This PR adds [ODIN II](https://github.com/verilog-to-routing/vtr-verilog-to-routing/tree/master/ODIN_II) package that similarly to #39 will be used in SymbiFlow/sv-tests#183

This differs from the `vtr` package by building the `odin_II` binary and using mainline `vtr` repository instead of our fork