### PR TITLE
Add sigrok-cli package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ env:
   # SystemVerilog tools
   - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
   - PACKAGE=odin_II             CONDA_CHANNELS="pkgw-forge,conda-forge"
+  # protocol analyzers
+  - PACKAGE=sigrok-cli          CONDA_CHANNELS="conda-forge"
 
 script:
   - bash $TRAVIS_BUILD_DIR/.travis/script.sh

--- a/sigrok-cli/build.sh
+++ b/sigrok-cli/build.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+for f in libserialport libsigrok libsigrokdecode sigrok-cli
+do
+	cd $f
+	./autogen.sh
+	./configure --prefix=$PREFIX
+	make -j$CPU_COUNT
+	make install
+	cd -
+done
+
+$PREFIX/bin/sigrok-cli -V
+find $PREFIX/share -name "__pycache__" -exec rm -rv {} +

--- a/sigrok-cli/meta.yaml
+++ b/sigrok-cli/meta.yaml
@@ -1,0 +1,46 @@
+package:
+  name: sigrok-cli
+  version: {{ GIT_FULL_HASH }}
+
+source:
+  - git_url: https://github.com/sigrokproject/libserialport
+    git_rev: master
+    folder: libserialport
+  - git_url: https://github.com/sigrokproject/libsigrok
+    git_rev: master
+    folder: libsigrok
+  - git_url: https://github.com/sigrokproject/libsigrokdecode
+    git_rev: master
+    folder: libsigrokdecode
+  - git_url: https://github.com/sigrokproject/sigrok-cli
+    git_rev: master
+    folder: sigrok-cli
+
+build:
+  number: {{ '1%04i00%s'|format(GIT_DESCRIBE_NUMBER|int, os.environ.get('DATESTR')) }}
+  string: {{ '%04i'|format(GIT_DESCRIBE_NUMBER|int) }}.{{ os.environ.get('DATESTR') }}.{{ GIT_DESCRIBE_HASH }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - python {{ python }}
+    - pkg-config
+    - libusb
+    - libzip
+    - glib
+    - glibmm
+    - doxygen
+  host:
+    - python {{ python }}
+    - pkg-config
+    - libzip
+    - glib
+
+about:
+  home: http://sigrok.org/
+  license: GPLv3
+  summary: 'The sigrok project aims at creating a portable, cross-platform, Free/Libre/Open-Source signal analysis software suite that supports various device types (e.g. logic analyzers, oscilloscopes, and many more).'


### PR DESCRIPTION
The aim is to provide a current version of [sigrok-cli](https://sigrok.org/) tool for use with [usb-test-suite-testbenches](https://github.com/antmicro/usb-test-suite-testbenches) to decode captured USB signals.
Signed-off-by: Rafal Kapuscik <rkapuscik@antmicro.com>