### PR TITLE
Add slang package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ env:
   - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
   - PACKAGE=odin_II             CONDA_CHANNELS="pkgw-forge,conda-forge"
   - PACKAGE=tree-sitter-verilog
+  - PACKAGE=slang               CONDA_CHANNELS="conda-forge"
   # protocol analyzers
   - PACKAGE=sigrok-cli          CONDA_CHANNELS="conda-forge"
 

--- a/slang/build.sh
+++ b/slang/build.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+set -e
+set -x
+
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+sudo apt update
+sudo apt install -y gcc-8 g++-8
+
+export CC=gcc-8
+export CXX=g++-8
+
+mkdir build && cd build
+
+cmake .. -DSLANG_INCLUDE_TESTS=OFF
+
+make
+
+mkdir -p $PREFIX/bin
+
+install bin/* $PREFIX/bin

--- a/slang/meta.yaml
+++ b/slang/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: slang
+  version: {{ GIT_FULL_HASH }}
+
+source:
+  git_url: https://github.com/MikePopoloski/slang
+  git_rev: master
+  patches:
+    - static-build.patch
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - make
+    - cmake
+    - conan
+about:
+  home: https://github.com/MikePopoloski/slang
+  license: MIT
+  license_file: LICENSE
+  summary: 'Parser and compiler library for SystemVerilog'

--- a/slang/static-build.patch
+++ b/slang/static-build.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
+index 1b0c2aed..eb3f115b 100644
+--- a/tools/CMakeLists.txt
++++ b/tools/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ add_executable(depmap depmap/depmap.cpp)
+-target_link_libraries(depmap PRIVATE slang)
++target_link_libraries(depmap PRIVATE slang -static)
+ 
+ add_executable(driver driver/driver.cpp)
+-target_link_libraries(driver PRIVATE slang CONAN_PKG::CLI11)
++target_link_libraries(driver PRIVATE slang CONAN_PKG::CLI11 -static)
+ 
+ add_executable(rewriter rewriter/rewriter.cpp)
+-target_link_libraries(rewriter PRIVATE slang)
++target_link_libraries(rewriter PRIVATE slang -static)
+ 
+ if(FUZZ_TARGET)
+ 	message("Tweaking driver for fuzz testing")
+-- 
+2.23.0
+


### PR DESCRIPTION
Aim of this PR is to create [Slang](https://github.com/MikePopoloski/slang) conda package for use in SymbiFlow/sv-tests#183.

Slang uses features from C++17 which require at least gcc8 which is not available via `conda` or from default `apt` repositories. Correct gcc version is obtained from [ppa repository mentioned on Ubuntu wiki](https://wiki.ubuntu.com/ToolChain#PPA_packages)