### PR TITLE
Fix warnings in sigrok-cli

### DIFF
--- a/sigrok-cli/build.sh
+++ b/sigrok-cli/build.sh
@@ -7,6 +7,8 @@ if [ x"$TRAVIS" = xtrue ]; then
 	CPU_COUNT=2
 fi
 
+unset CXXFLAGS # Will be set by configure below
+
 for f in libserialport libsigrok libsigrokdecode sigrok-cli
 do
 	cd $f

--- a/sigrok-cli/meta.yaml
+++ b/sigrok-cli/meta.yaml
@@ -33,12 +33,26 @@ requirements:
     - libzip
     - glib
     - glibmm
+    # C++ bindings
     - doxygen
+    # Python bindings
+    - swig
   host:
     - python {{ python }}
     - pkg-config
     - libzip
     - glib
+    # C++ bindings
+    - glibmm
+    - libsigcpp
+    # Python bindings
+    - pygobject
+    - numpy
+  run:
+    - python {{ python }}
+    - libzip
+    - libsigcpp
+    - glibmm
 
 about:
   home: http://sigrok.org/


### PR DESCRIPTION
Add missing dependencies and enable bindings for Python and C++.

This fixes #44.

Signed-off-by: Rafal Kapuscik <rkapuscik@antmicro.com>