### PR TITLE
netlistsvg: Adding a tool for generation of diagrams from Verilog.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   - PACKAGE=icestorm
   - PACKAGE=iverilog
   - PACKAGE=verilator
+  - PACKAGE=netlistsvg          CONDA_CHANNELS="conda-forge"
   # SystemVerilog tools
   - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
   - PACKAGE=odin_II             CONDA_CHANNELS="pkgw-forge,conda-forge"

--- a/netlistsvg/build.sh
+++ b/netlistsvg/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+which npm
+ls $PWD
+npm install -g netlistsvg
+
+ls $PREFIX/lib/node_modules/netlistsvg
+ls $PREFIX/lib/node_modules/netlistsvg/doc
+ls $PREFIX/lib/node_modules/netlistsvg/lib/default.svg

--- a/netlistsvg/meta.yaml
+++ b/netlistsvg/meta.yaml
@@ -1,0 +1,33 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('vpr-', '')|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: netlistsvg
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/mithro/netlistsvg.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - nodejs
+  host:
+    - nodejs
+  run:
+    - nodejs
+    - yosys
+
+about:
+  home: https://nturley.github.io/netlistsvg/
+  license: MIT
+  license_file: LICENSE
+  summary: 'netlistsvg draws an SVG schematic from a yosys JSON netlist.'

--- a/netlistsvg/run_test.sh
+++ b/netlistsvg/run_test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e
+set +x
+
+echo "------------------------"
+
+echo $PWD
+which yosys
+which netlistsvg
+
+echo "------------------------"
+
+NETLISTSVG=$(which netlistsvg)
+NETLISTSVG_SKIN=$PREFIX/lib/node_modules/netlistsvg/lib/default.svg
+NETLISTSVG_EXAMPLES=$PREFIX/lib/node_modules/netlistsvg/examples/*
+cp -aR $NETLISTSVG_EXAMPLES .
+
+sed -i -e's/\( %\.[^ ]*\)png/\1svg/g' Makefile
+
+echo "------------------------"
+
+make \
+	NETLISTSVG=$NETLISTSVG \
+	NETLISTSVG_SKIN=$NETLISTSVG_SKIN \
+	build.all
+
+echo "------------------------"
+
+ls *.svg


### PR DESCRIPTION
Draws an SVG schematic from a JSON netlist.

You can see an online demo @ https://nturley.github.io/netlistsvg/

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>