### PR TITLE
Fix Slang static build

### DIFF
--- a/slang/build.sh
+++ b/slang/build.sh
@@ -16,6 +16,5 @@ cmake .. -DSLANG_INCLUDE_TESTS=OFF
 
 make
 
-mkdir -p $PREFIX/bin
-
-install bin/* $PREFIX/bin
+install -D bin/driver $PREFIX/bin/slang-driver
+install -D bin/rewriter $PREFIX/bin/slang-rewriter

--- a/slang/static-build.patch
+++ b/slang/static-build.patch
@@ -1,15 +1,11 @@
 diff --git a/tools/CMakeLists.txt b/tools/CMakeLists.txt
-index 1b0c2aed..eb3f115b 100644
+index c43a9226..ebe0c086 100644
 --- a/tools/CMakeLists.txt
 +++ b/tools/CMakeLists.txt
-@@ -1,11 +1,11 @@
- add_executable(depmap depmap/depmap.cpp)
--target_link_libraries(depmap PRIVATE slang)
-+target_link_libraries(depmap PRIVATE slang -static)
- 
+@@ -1,8 +1,8 @@
  add_executable(driver driver/driver.cpp)
--target_link_libraries(driver PRIVATE slang CONAN_PKG::CLI11)
-+target_link_libraries(driver PRIVATE slang CONAN_PKG::CLI11 -static)
+-target_link_libraries(driver PRIVATE slang)
++target_link_libraries(driver PRIVATE slang -static)
  
  add_executable(rewriter rewriter/rewriter.cpp)
 -target_link_libraries(rewriter PRIVATE slang)
@@ -17,6 +13,3 @@ index 1b0c2aed..eb3f115b 100644
  
  if(FUZZ_TARGET)
  	message("Tweaking driver for fuzz testing")
--- 
-2.23.0
-


### PR DESCRIPTION
Slang static build uses a patch for `CMakeLists.txt` but that file was modified recently and the patch no longer applies cleanly. This PR updates the patch to work with current Slang sources.