### PR TITLE
Add libxml2 override package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
 
 env:
   - PACKAGE=vtr                 CONDA_CHANNELS="pkgw-forge,conda-forge"
+  - PACKAGE=libxml2
   - PACKAGE=libusb
   - PACKAGE=yosys
   - PACKAGE=nextpnr

--- a/libxml2/0001-Clamp-_xmlOutputBuffer-written-value-to-INT_MAX.patch
+++ b/libxml2/0001-Clamp-_xmlOutputBuffer-written-value-to-INT_MAX.patch
@@ -1,0 +1,70 @@
+From 0100c548f72a9971767ce5f40ed8fd4809923fbc Mon Sep 17 00:00:00 2001
+From: Keith Rothman <25643-litghost@users.noreply.gitlab.gnome.org>
+Date: Tue, 8 Oct 2019 10:24:07 -0700
+Subject: [PATCH] Clamp _xmlOutputBuffer::written value to INT_MAX.
+
+If more than INT_MAX bytes are written to the _xmlOutputBuffer, then
+counter saturates at INT_MAX.  If tracking of more than INT_MAX bytes is
+required, custom callbacks should be created, per
+https://gitlab.gnome.org/GNOME/libxml2/issues/112#note_620930
+
+Signed-off-by: Keith Rothman <25643-litghost@users.noreply.gitlab.gnome.org>
+---
+ xmlIO.c | 20 +++++++++++++++++---
+ 1 file changed, 17 insertions(+), 3 deletions(-)
+
+diff --git a/xmlIO.c b/xmlIO.c
+index 2a1e2cb0..5606a7eb 100644
+--- a/xmlIO.c
++++ b/xmlIO.c
+@@ -2485,6 +2485,17 @@ xmlFreeParserInputBuffer(xmlParserInputBufferPtr in) {
+     xmlFree(in);
+ }
+ 
++static int clamped_add(int a, int b) {
++    long long c = a;
++    c += b;
++    if(c > INT_MAX)
++	return INT_MAX;
++    else if(c < INT_MIN)
++	return INT_MIN;
++    else
++	return c;
++}
++
+ #ifdef LIBXML_OUTPUT_ENABLED
+ /**
+  * xmlOutputBufferClose:
+@@ -3413,7 +3424,8 @@ xmlOutputBufferWrite(xmlOutputBufferPtr out, int len, const char *buf) {
+ 		out->error = XML_IO_WRITE;
+ 		return(ret);
+ 	    }
+-	    out->written += ret;
++	    // Clamp at INT_MAX.
++	    out->written = clamped_add(out->written, ret);
+ 	}
+ 	written += nbchars;
+     } while (len > 0);
+@@ -3609,7 +3621,8 @@ xmlOutputBufferWriteEscape(xmlOutputBufferPtr out, const xmlChar *str,
+ 		out->error = XML_IO_WRITE;
+ 		return(ret);
+ 	    }
+-	    out->written += ret;
++	    // Clamp at INT_MAX.
++	    out->written = clamped_add(out->written, ret);
+ 	} else if (xmlBufAvail(out->buffer) < MINLEN) {
+ 	    xmlBufGrow(out->buffer, MINLEN);
+ 	}
+@@ -3703,7 +3716,8 @@ xmlOutputBufferFlush(xmlOutputBufferPtr out) {
+ 	out->error = XML_IO_FLUSH;
+ 	return(ret);
+     }
+-    out->written += ret;
++    // Clamp at INT_MAX.
++    out->written = clamped_add(out->written, ret);
+ 
+ #ifdef DEBUG_INPUT
+     xmlGenericError(xmlGenericErrorContext,
+-- 
+2.23.0.581.g78d2f28ef7-goog
+

--- a/libxml2/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+++ b/libxml2/0002-Make-and-install-a-pkg-config-file-on-Windows.patch
@@ -1,0 +1,48 @@
+From f90d931fa6f400065189b44d00273979709c700b Mon Sep 17 00:00:00 2001
+From: Peter Williams <peter@newton.cx>
+Date: Wed, 5 Sep 2018 16:50:54 -0400
+Subject: [PATCH] Make and install a pkg-config file on Windows.
+
+---
+ win32/Makefile.msvc | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/win32/Makefile.msvc b/win32/Makefile.msvc
+index 491dc88..415ec0b 100644
+--- a/win32/Makefile.msvc
++++ b/win32/Makefile.msvc
+@@ -282,7 +282,21 @@ _VC_MANIFEST_EMBED_EXE=
+ _VC_MANIFEST_EMBED_DLL=
+ !endif
+ 
+-all : libxml libxmla libxmladll utils
++all : libxml libxmla libxmladll utils libxml-2.0.pc
++
++# Note hardcoded libraries and trouble getting dollar-sign/brace variables working
++libxml-2.0.pc:
++        echo prefix=$(PREFIX:\=/) >$@
++        echo exec_prefix=$(PREFIX:\=/) >>$@
++        echo libdir=$(LIBPREFIX:\=/) >>$@
++        echo includedir=$(INCPREFIX:\=/) >>$@
++        echo modules=0 >>$@
++        echo Name: libXML >>$@
++        echo Version: $(LIBXML_MAJOR_VERSION).$(LIBXML_MINOR_VERSION).$(LIBXML_MICRO_VERSION) >>$@
++        echo Description: libXML library version2. >>$@
++        echo Requires: >>$@
++        echo Libs: -L$(LIBPREFIX:\=/) -lxml2 -liconv -lz >>$@
++        echo Cflags: -I$(INCPREFIX:\=/)/libxml >>$@
+ 
+ libxml : $(BINDIR)\$(XML_SO) 
+ 
+@@ -320,6 +334,8 @@ install-libs : all
+ install : install-libs 
+ 	copy $(BINDIR)\*.exe $(BINPREFIX)
+ 	-copy $(BINDIR)\*.pdb $(BINPREFIX)
++	if not exist $(LIBPREFIX)\pkgconfig mkdir $(LIBPREFIX)\pkgconfig
++	copy libxml-2.0.pc $(LIBPREFIX)\pkgconfig
+ 
+ install-dist : install-libs 
+ 	copy $(BINDIR)\xml*.exe $(BINPREFIX)
+-- 
+2.17.1
+

--- a/libxml2/0004-CVE-2017-8872.patch
+++ b/libxml2/0004-CVE-2017-8872.patch
@@ -1,0 +1,31 @@
+From: Marcus Meissner <meissner@suse.de>
+Date: Wed, 3 Jan 2018 14:43:41 +0100
+Subject: Out-of-bounds read in htmlParseTryOrFinish
+
+Origin: vendor, https://bugzilla.novell.com/attachment.cgi?id=732309
+Bug: https://bugzilla.gnome.org/show_bug.cgi?id=775200
+Bug-Debian: https://bugs.debian.org/862450
+Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2017-8872
+Bug-SUSE: https://bugzilla.novell.com/show_bug.cgi?id=1038444
+Forwarded: yes, https://bugzilla.gnome.org/attachment.cgi?id=366193
+Reviewed-by: Salvatore Bonaccorso <carnil@debian.org>
+Last-Update: 2018-01-03
+---
+ parser.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/parser.c b/parser.c
+index 1c5e036..0251110 100644
+--- a/parser.c
++++ b/parser.c
+@@ -12467,6 +12467,10 @@ xmlHaltParser(xmlParserCtxtPtr ctxt) {
+ 	ctxt->input->cur = BAD_CAST"";
+ 	ctxt->input->base = ctxt->input->cur;
+         ctxt->input->end = ctxt->input->cur;
++    if (ctxt->input->buf)
++        xmlBufEmpty (ctxt->input->buf->buffer);
++    else
++        ctxt->input->length = 0;
+     }
+ }
+ 

--- a/libxml2/README.md
+++ b/libxml2/README.md
@@ -1,0 +1,15 @@
+libxml2 feedstock forked from https://github.com/conda-forge/libxml2-feedstock
+
+BSD 3-clause license
+Copyright (c) 2015-2019, conda-forge
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/libxml2/bld.bat
+++ b/libxml2/bld.bat
@@ -1,0 +1,32 @@
+
+cd win32
+
+:: Have to set manifest for VS2008.
+:: No idea why, but exe's won't run otherwise.
+set MANIFEST=no
+if "%VS_MAJOR%" == "9" (
+    set MANIFEST=yes
+)
+
+cscript configure.js compiler=msvc iconv=yes icu=no zlib=yes lzma=no python=no ^
+                     vcmanifest=%MANIFEST% ^
+                     prefix=%LIBRARY_PREFIX% ^
+                     include=%LIBRARY_INC% ^
+                     lib=%LIBRARY_LIB%
+
+if errorlevel 1 exit 1
+
+nmake /f Makefile.msvc
+if errorlevel 1 exit 1
+
+nmake /f Makefile.msvc install
+if errorlevel 1 exit 1
+
+:: For some reason the includes get put down one level.
+move %LIBRARY_INC%\libxml2\libxml %LIBRARY_INC%
+if errorlevel 1 exit 1
+
+rmdir %LIBRARY_INC%\libxml2
+del %LIBRARY_PREFIX%\bin\test*.exe || exit 1
+del %LIBRARY_PREFIX%\bin\runsuite.exe || exit 1
+del %LIBRARY_PREFIX%\bin\runtest.exe || exit 1

--- a/libxml2/build.sh
+++ b/libxml2/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+./autogen.sh
+
+./configure --prefix="${PREFIX}" \
+            --build=${BUILD} \
+            --host=${HOST} \
+            --with-iconv="${PREFIX}" \
+            --with-zlib="${PREFIX}" \
+            --with-icu \
+            --with-lzma="${PREFIX}" \
+            --without-python \
+            --enable-static=no
+make -j${CPU_COUNT} ${VERBOSE_AT}
+# Sorry:
+# ## Error cases regression tests
+# file result/errors/759573.xml.err is 1983 bytes, result is 1557 bytes
+# Error for ./test/errors/759573.xml failed
+# if [[ ${target_platform} != osx-64 ]]; then
+#   make check $VERBOSE_AT}
+# fi
+make install

--- a/libxml2/build.sh
+++ b/libxml2/build.sh
@@ -5,9 +5,9 @@
 ./configure --prefix="${PREFIX}" \
             --build=${BUILD} \
             --host=${HOST} \
-            --with-iconv="${PREFIX}" \
+            --without-iconv \
             --with-zlib="${PREFIX}" \
-            --with-icu \
+            --without-icu \
             --with-lzma="${PREFIX}" \
             --without-python \
             --enable-static=no

--- a/libxml2/meta.yaml
+++ b/libxml2/meta.yaml
@@ -28,15 +28,10 @@ requirements:
     - pkg-config  # [not win]
     - make  # [not win]
     - m2-patch  # [win]
-    - icu  # [not win]
   host:
-    - icu  # [not win]
-    - libiconv
     - xz  # [not win]
     - zlib
   run:
-    - icu  # [not win]
-    - libiconv
     - xz  # [not win]
     - zlib
 

--- a/libxml2/meta.yaml
+++ b/libxml2/meta.yaml
@@ -1,0 +1,69 @@
+{% set version = "2.9.9" %}
+
+package:
+  name: libxml2
+  version: {{ version }}
+
+source:
+  url: http://xmlsoft.org/sources/libxml2-{{ version }}.tar.gz
+  sha256: 94fb70890143e3c6549f265cee93ec064c80a84c42ad0f23e85ee1fd6540a871
+  patches:
+    - 0001-Clamp-_xmlOutputBuffer-written-value-to-INT_MAX.patch
+    - 0002-Make-and-install-a-pkg-config-file-on-Windows.patch
+    - 0004-CVE-2017-8872.patch
+
+build:
+  number: 5
+  run_exports:
+    # remove symbols at minor versions.
+    #    https://abi-laboratory.pro/tracker/timeline/libxml2/
+    - {{ pin_subpackage('libxml2', max_pin='x.x') }}
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - autoconf  # [not win]
+    - automake  # [not win]
+    - libtool  # [not win]
+    - pkg-config  # [not win]
+    - make  # [not win]
+    - m2-patch  # [win]
+    - icu  # [not win]
+  host:
+    - icu  # [not win]
+    - libiconv
+    - xz  # [not win]
+    - zlib
+  run:
+    - icu  # [not win]
+    - libiconv
+    - xz  # [not win]
+    - zlib
+
+test:
+  files:
+    - test.xml
+  commands:
+    - xmllint test.xml
+
+about:
+  home: http://xmlsoft.org/
+  license: MIT
+  license_family: MIT
+  license_file: Copyright
+  summary: The XML C parser and toolkit of Gnome
+  description: |
+     Though libxml2 is written in C a variety of language
+     bindings make it available in other environments.
+  doc_url: http://xmlsoft.org/html/index.html
+  doc_source_url: https://github.com/GNOME/libxml2/blob/master/doc/index.html
+  dev_url: https://git.gnome.org/browse/libxml2/
+
+extra:
+  recipe-maintainers:
+    - ocefpaf
+    - jakirkham
+    - gillins
+    - jschueller
+    - msarahan
+    - scopatz

--- a/libxml2/test.xml
+++ b/libxml2/test.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<HTML xmlns:pp="http://www.isogen.com/paul/post-processor">
+<TITLE>Introduction to XSL</TITLE>
+<H1>Introduction to XSL</H1>
+
+
+
+                <HR/>
+                <H2>Overview
+</H2>
+                <UL>
+
+        <LI>1.Intro</LI>
+
+        <LI>2.History</LI>
+
+        <LI>3.XSL Basics</LI>
+
+        <LI>Lunch</LI>
+
+        <LI>4.An XML Data Model</LI>
+
+        <LI>5.XSL Patterns</LI>
+
+        <LI>6.XSL Templates</LI>
+
+        <LI>7.XSL Formatting Model
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>Intro</H2>
+                <UL>
+
+        <LI>Who am I?</LI>
+
+        <LI>Who are you?</LI>
+
+        <LI>Why are we here?
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: XML and SGML</H2>
+                <UL>
+
+        <LI>XML is a subset of SGML.</LI>
+
+        <LI>SGML allows the separation of abstract content from formatting.</LI>
+
+        <LI>Also one of XML's primary virtues (in the doc publishing domain).
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: What are stylesheets?</H2>
+                <UL>
+
+        <LI>Stylesheets specify the formatting of SGML/XML documents.</LI>
+
+        <LI>Stylesheets put the &quot;style&quot; back into documents.</LI>
+
+        <LI>New York Times content+NYT Stylesheet = NYT paper
+</LI>
+
+                </UL>
+
+
+
+
+
+
+                <HR/>
+                <H2>History: FOSI</H2>
+                <UL>
+
+        <LI>FOSI: &quot;Formatted Output Specification Instance&quot;
+<UL>
+        <LI>MIL-STD-28001
+        </LI>
+
+        <LI>FOSI's are SGML documents
+        </LI>
+
+        <LI>A stylesheet for another document
+        </LI>
+</UL></LI>
+
+        <LI>Obsolete but implemented...
+</LI>
+
+                </UL>
+
+
+
+
+</HTML>


### PR DESCRIPTION
This is to have the clamp'd xmlOutputBuffer fix, which is in upstream,
but not integrated into a release.

Once libxml2 publishes a version with the fix and conda-forge has
ingested it, this package can be removed from Symbiflow/conda-packages.