### PR TITLE
fix issue with slang version string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
 
 before_install:
  - source $TRAVIS_BUILD_DIR/.travis/common.sh
+ - source $TRAVIS_BUILD_DIR/.travis/tag-filter.sh
  - bash $TRAVIS_BUILD_DIR/.travis/fixup-git.sh
  - source $TRAVIS_BUILD_DIR/.travis/common.sh
 

--- a/.travis/tag-filter.sh
+++ b/.travis/tag-filter.sh
@@ -1,0 +1,31 @@
+TAG_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | awk '{print $2}')
+TAG_GIT_REV=$(cat $PACKAGE/meta.yaml | grep "git_rev" | awk '{print $2}')
+TAG_PATTERN=${TAG_PATTERN:-"v[0-9]*\.[0-9]*"}
+
+TAG_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$TAG_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
+
+git clone --mirror --branch "$TAG_GIT_REV" "$TAG_GIT_URL" $TAG_GIT_DIR
+
+TAG_DESC_OUT=$(GIT_DIR=$TAG_GIT_DIR git describe --tags --long HEAD --first-parent --match "$TAG_PATTERN")
+
+TAG_OLD_IFS=$IFS
+
+IFS='-'
+
+read -ra TAG_DESC_ARR <<< "$TAG_DESC_OUT"
+
+if [ ${#TAG_DESC_ARR[@]} == 3 ]; then
+    export PKG_TAG=${TAG_DESC_ARR[0]}
+    export PKG_NUMBER=${TAG_DESC_ARR[1]}
+    export PKG_GIT_HASH=${TAG_DESC_ARR[2]}
+else
+    export PKG_TAG="v0.0"
+    export PKG_NUMBER=$(GIT_DIR=$TAG_GIT_DIR git rev-list --count HEAD)
+    export PKG_GIT_HASH=g$(GIT_DIR=$TAG_GIT_DIR git rev-parse --short HEAD)
+fi
+
+IFS=$TAG_OLD_IFS
+
+echo "     PKG_TAG: $PKG_TAG"
+echo "  PKG_NUMBER: $PKG_NUMBER"
+echo "PKG_GIT_HASH: $PKG_GIT_HASH"

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+export CONDA_PATH=${CONDA_PATH:-~/conda}
+if [ ! -d $CONDA_PATH ];then
+	echo "Conda not found at $CONDA_PATH"
+	exit 1
+fi
+if [ ! -f $CONDA_PATH/bin/activate ];then
+	echo "conda's bin/activate not found in $CONDA_PATH"
+	exit 1
+fi
+
+export PATH=$CONDA_PATH/bin:$PATH
+
 # Disable this warning;
 # xxxx/conda_build/environ.py:377: UserWarning: The environment variable
 #     'TRAVIS' is being passed through with value 0.  If you are splitting

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -34,4 +34,7 @@ export TRAVIS_REPO_SLUG="$(git rev-parse --abbrev-ref --symbolic-full-name @{u})
 echo "TRAVIS_REPO_SLUG='${TRAVIS_REPO_SLUG}'"
 
 ./conda-meta-extra.sh
+
+source .travis/tag-filter.sh
+
 conda $@

--- a/moore/meta.yaml
+++ b/moore/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: moore
   version: {{ version }}

--- a/odin_II/meta.yaml
+++ b/odin_II/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('vpr-', '')|replace('-v','.')|replace('-rc','_rc') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 
 package:
   name: odin_ii

--- a/slang/meta.yaml
+++ b/slang/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: slang
   version: {{ version }}

--- a/surelog/meta.yaml
+++ b/surelog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: surelog
   version: {{ version }}

--- a/sv-parser/meta.yaml
+++ b/sv-parser/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: sv-parser
   version: {{ version }}

--- a/tree-sitter-verilog/meta.yaml
+++ b/tree-sitter-verilog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: tree-sitter-verilog
   version: {{ version }}

--- a/verible/meta.yaml
+++ b/verible/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG|replace('-','_'), PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: verible
   version: {{ version }}

--- a/zachjs-sv2v/meta.yaml
+++ b/zachjs-sv2v/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(PKG_TAG, PKG_NUMBER|int, PKG_GIT_HASH) %}
 package:
   name: zachjs-sv2v
   version: {{ version }}


### PR DESCRIPTION
using tag name and number of commits since that tag as version creates issues when tags in the repository are not getting sorted properly ie. conda sees nightly as lower version compared to v0.1
as can be seen [here](https://anaconda.org/SymbiFlow/slang). ~Using date of the last commit seems to be the most reliable solution.~ As pointed out in SymbiFlow/sv-tests#633 this is currently an issue in sv-tests.