### PR TITLE
Rework conda builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
  - ./.travis/install.sh
 
 env:
-  - PACKAGE=vtr                 CONDA_CHANNELS="pkgw-forge,conda-forge"
+  - PACKAGE=vtr
   - PACKAGE=libxml2
   - PACKAGE=libusb
   - PACKAGE=yosys
@@ -31,18 +31,18 @@ env:
   - PACKAGE=icestorm
   - PACKAGE=iverilog
   - PACKAGE=verilator
-  - PACKAGE=netlistsvg          CONDA_CHANNELS="conda-forge"
+  - PACKAGE=netlistsvg
   # SystemVerilog tools
-  - PACKAGE=zachjs-sv2v         CONDA_CHANNELS="conda-forge"
-  - PACKAGE=odin_II             CONDA_CHANNELS="pkgw-forge,conda-forge"
+  - PACKAGE=zachjs-sv2v
+  - PACKAGE=odin_II
   - PACKAGE=tree-sitter-verilog
-  - PACKAGE=slang               CONDA_CHANNELS="conda-forge"    USE_SYSTEM_GCC_VERSION="8"
+  - PACKAGE=slang               USE_SYSTEM_GCC_VERSION="8"
   - PACKAGE=moore
-  - PACKAGE=surelog             CONDA_CHANNELS="conda-forge"
+  - PACKAGE=surelog
   - PACKAGE=sv-parser
-  - PACKAGE=verible                                             USE_SYSTEM_GCC_VERSION="8"
+  - PACKAGE=verible             USE_SYSTEM_GCC_VERSION="8"
   # protocol analyzers
-  - PACKAGE=sigrok-cli          CONDA_CHANNELS="conda-forge"
+  - PACKAGE=sigrok-cli
   - PACKAGE=yosys-plugins
 
 script:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -15,34 +15,21 @@ start_section "environment.conda" "Setting up basic ${YELLOW}conda environment${
 mkdir -p $BASE_PATH
 ./conda-get.sh $CONDA_PATH
 hash -r
-conda config --set always_yes yes --set changeps1 no
-conda install pexpect
-conda config --add channels timvideos
-for CHANNEL in $(echo $CONDA_CHANNELS | tr ',' ' '); do
-	conda config --add channels $CHANNEL
-done
-conda config --add channels $(echo $TRAVIS_REPO_SLUG | sed -e's@/.*$@@')
-#conda clean -s --dry-run
-conda build purge
-#conda clean -s --dry-run
-
-./conda-meta-extra.sh
-
 end_section "environment.conda"
 
 $SPACER
 
 # Output some useful info
 start_section "info.conda.env" "Info on ${YELLOW}conda environment${NC}"
-conda info
+./conda-env.sh info
 end_section "info.conda.env"
 
 start_section "info.conda.config" "Info on ${YELLOW}conda config${NC}"
-conda config --show
+./conda-env.sh config --show
 end_section "info.conda.config"
 
 start_section "info.conda.package" "Info on ${YELLOW}conda package${NC}"
-conda render --no-source $CONDA_BUILD_ARGS || true
+./conda-env.sh render --no-source $CONDA_BUILD_ARGS || true
 end_section "info.conda.package"
 
 $SPACER
@@ -56,5 +43,5 @@ end_section "conda.copy"
 $SPACER
 
 start_section "conda.download" "${GREEN}Downloading..${NC}"
-travis_wait conda build --source $CONDA_BUILD_ARGS || true
+travis_wait ./conda-env.sh build --source $CONDA_BUILD_ARGS || true
 end_section "conda.download"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -43,5 +43,5 @@ end_section "conda.copy"
 $SPACER
 
 start_section "conda.download" "${GREEN}Downloading..${NC}"
-travis_wait ./conda-env.sh build --source $CONDA_BUILD_ARGS || true
+./conda-env.sh build --source $CONDA_BUILD_ARGS || true
 end_section "conda.download"

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,25 +6,25 @@ set -e
 $SPACER
 
 start_section "info.conda.package" "Info on ${YELLOW}conda package${NC}"
-conda render $CONDA_BUILD_ARGS
+./conda-env.sh render $CONDA_BUILD_ARGS
 end_section "info.conda.package"
 
 $SPACER
 
 start_section "conda.check" "${GREEN}Checking...${NC}"
-conda build --check $CONDA_BUILD_ARGS || true
+./conda-env.sh build --check $CONDA_BUILD_ARGS || true
 end_section "conda.check"
 
 $SPACER
 
 start_section "conda.build" "${GREEN}Building..${NC}"
-$CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
+$CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log ./conda-env.sh build $CONDA_BUILD_ARGS
 end_section "conda.build"
 
 $SPACER
 
 start_section "conda.build" "${GREEN}Installing..${NC}"
-conda install $CONDA_OUT
+./conda-env.sh install $CONDA_OUT
 end_section "conda.build"
 
 $SPACER

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -35,16 +35,16 @@ fi
 export TRAVIS=0
 export CI=0
 
-export TRAVIS_EVENT_TYPE="local"
+export TRAVIS_EVENT_TYPE=${TRAVIS_EVENT_TYPE:-"local"}
 echo "TRAVIS_EVENT_TYPE='${TRAVIS_EVENT_TYPE}'"
 
-export TRAVIS_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+export TRAVIS_BRANCH="${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 echo "TRAVIS_BRANCH='${TRAVIS_BRANCH}'"
 
-export TRAVIS_COMMIT="$(git rev-parse HEAD)"
+export TRAVIS_COMMIT="${TRAVIS_BRANCH:-$(git rev-parse HEAD)}"
 echo "TRAVIS_COMMIT='${TRAVIS_COMMIT}'"
 
-export TRAVIS_REPO_SLUG="$(git rev-parse --abbrev-ref --symbolic-full-name @{u})"
+export TRAVIS_REPO_SLUG="${TRAVIS_REPO_SLUG:-$(git remote get-url origin | sed -e's-.*github\.com/--' -e's/\.git//')}"
 echo "TRAVIS_REPO_SLUG='${TRAVIS_REPO_SLUG}'"
 
 # >>> conda initialize >>>

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+export CONDA_PATH=${CONDA_PATH:-~/conda}
+if [ ! -d $CONDA_PATH ];then
+	echo "Conda not found at $CONDA_PATH"
+	exit 1
+fi
+if [ ! -f $CONDA_PATH/bin/activate ];then
+	echo "conda's bin/activate not found in $CONDA_PATH"
+	exit 1
+fi
+export PATH=$CONDA_PATH/bin:$PATH
+
 # Disable this warning;
 # xxxx/conda_build/environ.py:377: UserWarning: The environment variable
 #     'TRAVIS' is being passed through with value 0.  If you are splitting

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -70,4 +70,5 @@ if [ ! -d $PACKAGE_ENV ]; then
 fi
 conda activate $PACKAGE
 ./conda-meta-extra.sh $PACKAGE
+./conda-tag-filter.sh $PACKAGE
 conda $@

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -9,7 +9,6 @@ if [ ! -f $CONDA_PATH/bin/activate ];then
 	echo "conda's bin/activate not found in $CONDA_PATH"
 	exit 1
 fi
-export PATH=$CONDA_PATH/bin:$PATH
 
 # Disable this warning;
 # xxxx/conda_build/environ.py:377: UserWarning: The environment variable
@@ -43,6 +42,21 @@ echo "TRAVIS_COMMIT='${TRAVIS_COMMIT}'"
 
 export TRAVIS_REPO_SLUG="$(git rev-parse --abbrev-ref --symbolic-full-name @{u})"
 echo "TRAVIS_REPO_SLUG='${TRAVIS_REPO_SLUG}'"
+
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$("$CONDA_PATH/bin/conda" 'shell.bash' 'hook' 2> /dev/null)"
+if [ $? -eq 0 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "$CONDA_PATH/etc/profile.d/conda.sh" ]; then
+        . "$CONDA_PATH/etc/profile.d/conda.sh"
+    else
+        export PATH="$CONDA_PATH/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
 
 ./conda-meta-extra.sh
 conda $@

--- a/conda-env.sh
+++ b/conda-env.sh
@@ -9,6 +9,10 @@ if [ ! -f $CONDA_PATH/bin/activate ];then
 	echo "conda's bin/activate not found in $CONDA_PATH"
 	exit 1
 fi
+if [ x$PACKAGE = x"" ]; then
+	echo "\$PACKAGE not set."
+	exit 1
+fi
 
 # Disable this warning;
 # xxxx/conda_build/environ.py:377: UserWarning: The environment variable
@@ -58,5 +62,12 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 
-./conda-meta-extra.sh
+export CONDARC=$CONDA_PATH/.condarc
+PACKAGE_ENV=$CONDA_PATH/envs/$PACKAGE
+if [ ! -d $PACKAGE_ENV ]; then
+	conda create --yes --name $PACKAGE --strict-channel-priority
+	ln -sf $(realpath $PACKAGE/condarc) $PACKAGE_ENV/condarc
+fi
+conda activate $PACKAGE
+./conda-meta-extra.sh $PACKAGE
 conda $@

--- a/conda-get.sh
+++ b/conda-get.sh
@@ -58,6 +58,6 @@ cat >> $CONDA_PATH/condarc <<'EOF'
 EOF
 
 # Install required build tools
-conda install -y conda-build anaconda-client jinja2 conda-verify ripgrep
+conda install -y conda-build anaconda-client jinja2 conda-verify ripgrep pexpect
 
 conda info | grep --color=always -e "^" -e "populated config files"

--- a/conda-get.sh
+++ b/conda-get.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -x
 set -e
 
 CONDA_PATH=${1:-~/conda}
@@ -9,7 +8,7 @@ echo "Downloading Conda installer."
 wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 chmod a+x Miniconda3-latest-Linux-x86_64.sh
 
-if [ ! -d $CONDA_PATH -o ! -z "$CI"  ]; then
+if [ ! -d $CONDA_PATH ]; then
 	echo "Installing conda"
         ./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_PATH -b -f
 fi
@@ -37,7 +36,6 @@ patch_conda
 
 cat > $CONDA_PATH/condarc <<'EOF'
 # Useful for automation
-always_yes: True
 show_channel_urls: True
 
 # Prevent conda from automagically updating things
@@ -45,6 +43,18 @@ auto_update_conda: False
 update_dependencies: False
 # Don't complain
 notify_outdated_conda: false
+# Add channels
+channels:
+EOF
+CONDA_CHANNEL=$(echo $TRAVIS_REPO_SLUG | sed -e's@/.*$@@')
+if [ x$CONDA_CHANNEL != x ];then
+cat >> $CONDA_PATH/condarc <<EOF
+ - $CONDA_CHANNEL
+EOF
+fi
+cat >> $CONDA_PATH/condarc <<'EOF'
+ - symbiflow
+ - defaults
 EOF
 
 # Install required build tools

--- a/conda-get.sh
+++ b/conda-get.sh
@@ -44,6 +44,7 @@ update_dependencies: False
 # Don't complain
 notify_outdated_conda: false
 # Add channels
+channel_priority: strict
 channels:
 EOF
 CONDA_CHANNEL=$(echo $TRAVIS_REPO_SLUG | sed -e's@/.*$@@')

--- a/conda-meta-extra.sh
+++ b/conda-meta-extra.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
-TOP=$(pwd)
 
-cat > recipe_append.yaml <<EOF
+PACKAGE=${1:-PACKAGE}
+if [ x$PACKAGE = x"" ]; then
+	echo "\$PACKAGE not set!"
+	exit 1
+fi
+
+rm -f $PACKAGE/recipe_append.yaml
+cat > $PACKAGE/recipe_append.yaml <<EOF
 extra:
   maintainers:
     - Tim 'mithro' Ansell <mithro@mithis.com>
@@ -17,10 +23,6 @@ extra:
     describe: $GITREV
     date:     $DATESTR
 EOF
-
-for meta in $(find -name meta.yaml); do
-	(
-		cd $(dirname $meta);
-		ln -sf $(python3 -c "import os.path; print(os.path.relpath('$TOP/recipe_append.yaml'))") recipe_append.yaml
-	)
-done
+if [ -e $PACKAGE/condarc ]; then
+	cat $PACKAGE/condarc | sed -e's/^/  /' >> $PACKAGE/recipe_append.yaml
+fi

--- a/conda-tag-filter.sh
+++ b/conda-tag-filter.sh
@@ -8,9 +8,7 @@ TAG_PATTERN='^v[0-9]+\.[0-9]+(\.[0-9])?$'
 
 CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | awk '{print $2}')
 CONDA_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$CONDA_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
-echo "Conda git cache dir: '$CONDA_GIT_DIR'"
 if [ ! -d $CONDA_GIT_DIR ]; then
-	echo "URL='$CONDA_GIT_URL' DIR='$CONDA_GIT_DIR'"
 	git clone --bare "$CONDA_GIT_URL" $CONDA_GIT_DIR
 fi
 (
@@ -45,12 +43,11 @@ fi
 			echo
 		fi
 		git rev-parse HEAD > $GIT_DIR/TAG_FILTER
+
+		# List the remaining tags
+		echo "Remaining tags"
+		git tag --list | sort --version-sort | sed -e's/^/ * /'
+		echo
 	fi
-
-	# List the remaining tags
-	echo "Remaining tags"
-	git tag --list | sort --version-sort | sed -e's/^/ * /'
-	echo
-
 	echo "Git describe output: '$(git describe --tags)'"
 )

--- a/conda-tag-filter.sh
+++ b/conda-tag-filter.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -e
+
+PACKAGE=${1:-PACKAGE}
+
+TAG_PATTERN='^v[0-9]+\.[0-9]+(\.[0-9])?$'
+
+CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | awk '{print $2}')
+CONDA_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$CONDA_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
+echo "Conda git cache dir: '$CONDA_GIT_DIR'"
+if [ ! -d $CONDA_GIT_DIR ]; then
+	git clone --bare "$CONDA_GIT_URL" $CONDA_GIT_DIR
+fi
+(
+	export GIT_DIR=$CONDA_GIT_DIR
+	# Disable automatic fetching of tags
+	git config remote.origin.tagOpt --no-tags
+
+	# Manually fetch the tags
+	echo "Fetching tags.."
+	git fetch --tags
+	echo
+
+	echo "Initial set of tags:"
+	git tag --list | grep --color=always -e "^" -e $TAG_PATTERN | sed -e's/^/ * /'
+	echo
+
+	# Remove all the non-version tags
+	for TAG in $(git tag --list | sort --version-sort | grep -P -v $TAG_PATTERN); do
+		git tag -d $TAG
+	done
+	echo
+
+	# Add a tag if it doesn't exist
+	if [ $(git tag --list | wc -l) -eq 0 ]; then
+		OLDEST_COMMIT=$(git log --reverse --pretty=%H | head -n1)
+		echo "Adding v0.0 to $OLDEST_COMMIT (first commit in repository!)"
+		git tag -a v0.0 $OLDEST_COMMIT -m"v0.0"
+		echo
+	fi
+
+	# List the remaining tags
+	echo "Remaining tags"
+	git tag --list | sed -e's/^/ * /'
+	echo
+
+	echo "Git describe output: '$(git describe --tags)'"
+)

--- a/conda-tag-filter.sh
+++ b/conda-tag-filter.sh
@@ -10,39 +10,46 @@ CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | awk '{print $2}')
 CONDA_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$CONDA_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
 echo "Conda git cache dir: '$CONDA_GIT_DIR'"
 if [ ! -d $CONDA_GIT_DIR ]; then
+	echo "URL='$CONDA_GIT_URL' DIR='$CONDA_GIT_DIR'"
 	git clone --bare "$CONDA_GIT_URL" $CONDA_GIT_DIR
 fi
 (
 	export GIT_DIR=$CONDA_GIT_DIR
-	# Disable automatic fetching of tags
-	git config remote.origin.tagOpt --no-tags
 
-	# Manually fetch the tags
-	echo "Fetching tags.."
-	git fetch --tags
-	echo
+	CURRENT_HEAD=$(git rev-parse HEAD)
+	LAST_HEAD=$(cat $GIT_DIR/TAG_FILTER 2> /dev/null || true)
+	if [ g"$LAST_HEAD" != g"$CURRENT_HEAD" ]; then
+		# Disable automatic fetching of tags
+		git config remote.origin.tagOpt --no-tags
 
-	echo "Initial set of tags:"
-	git tag --list | grep --color=always -e "^" -e $TAG_PATTERN | sed -e's/^/ * /'
-	echo
-
-	# Remove all the non-version tags
-	for TAG in $(git tag --list | sort --version-sort | grep -P -v $TAG_PATTERN); do
-		git tag -d $TAG
-	done
-	echo
-
-	# Add a tag if it doesn't exist
-	if [ $(git tag --list | wc -l) -eq 0 ]; then
-		OLDEST_COMMIT=$(git log --reverse --pretty=%H | head -n1)
-		echo "Adding v0.0 to $OLDEST_COMMIT (first commit in repository!)"
-		git tag -a v0.0 $OLDEST_COMMIT -m"v0.0"
+		# Manually fetch the tags
+		echo "Fetching tags.."
+		git fetch --tags
 		echo
+
+		echo "Initial set of tags:"
+		git tag --list | sort --version-sort | grep --color=always -e "^" -e $TAG_PATTERN | sed -e's/^/ * /'
+		echo
+
+		# Remove all the non-version tags
+		for TAG in $(git tag --list | sort --version-sort | grep -P -v $TAG_PATTERN); do
+			git tag -d $TAG
+		done
+		echo
+
+		# Add a tag if it doesn't exist
+		if [ $(git tag --list | wc -l) -eq 0 ]; then
+			OLDEST_COMMIT=$(git log --reverse --pretty=%H | head -n1)
+			echo "Adding v0.0 to $OLDEST_COMMIT (first commit in repository!)"
+			git tag -a v0.0 $OLDEST_COMMIT -m"v0.0"
+			echo
+		fi
+		git rev-parse HEAD > $GIT_DIR/TAG_FILTER
 	fi
 
 	# List the remaining tags
 	echo "Remaining tags"
-	git tag --list | sed -e's/^/ * /'
+	git tag --list | sort --version-sort | sed -e's/^/ * /'
 	echo
 
 	echo "Git describe output: '$(git describe --tags)'"

--- a/icestorm/meta.yaml
+++ b/icestorm/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/SymbiFlow/icestorm.git
+  git_url: https://github.com/cliffordwolf/icestorm.git
   git_rev: master
   patches:
    - noiceprog.patch

--- a/netlistsvg/condarc
+++ b/netlistsvg/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/nextpnr/meta.yaml
+++ b/nextpnr/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/SymbiFlow/nextpnr.git
+  git_url: https://github.com/YosysHQ/nextpnr.git
   git_rev: master
 
 build:

--- a/odin_II/condarc
+++ b/odin_II/condarc
@@ -1,0 +1,3 @@
+channels:
+  - pkgw-forge
+  - conda-forge

--- a/openocd/condarc
+++ b/openocd/condarc
@@ -1,0 +1,3 @@
+# Temporarily to for libftdi
+channels:
+  - litex-hub

--- a/openocd/meta.yaml
+++ b/openocd/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   git_rev: master
-  git_url: git://repo.or.cz/openocd.git
+  git_url: http://git.code.sf.net/p/openocd/code
   patches:
     - digilent-arty.patch
     - digilent-cmod-a7.patch

--- a/sigrok-cli/condarc
+++ b/sigrok-cli/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/sigrok-cli/meta.yaml
+++ b/sigrok-cli/meta.yaml
@@ -4,7 +4,7 @@ package:
   version: {{ version }}
 
 source:
-  - git_url: https://github.com/SymbiFlow/sigrok-cli
+  - git_url: https://github.com/sigrokproject/sigrok-cli
     git_rev: master
     folder: sigrok-cli
   - git_url: https://github.com/sigrokproject/libserialport

--- a/slang/condarc
+++ b/slang/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/slang/meta.yaml
+++ b/slang/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v',''), GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH) %}
 package:
   name: slang
   version: {{ version }}

--- a/surelog/condarc
+++ b/surelog/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/vtr/condarc
+++ b/vtr/condarc
@@ -1,0 +1,3 @@
+channels:
+  - pkgw-forge
+  - conda-forge

--- a/zachjs-sv2v/condarc
+++ b/zachjs-sv2v/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge


### PR DESCRIPTION
 * Filters the tags in the downloaded git repository.
 * Installs the conda channels only into a specific environment for each package build.
 * Patch conda to stop it looking at the user's config file.