### PR TITLE
Improve conda-tag-filter script

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,15 +21,15 @@ $SPACER
 
 # Output some useful info
 start_section "info.conda.env" "Info on ${YELLOW}conda environment${NC}"
-./conda-env.sh info
+$TRAVIS_BUILD_DIR/conda-env.sh info
 end_section "info.conda.env"
 
 start_section "info.conda.config" "Info on ${YELLOW}conda config${NC}"
-./conda-env.sh config --show
+$TRAVIS_BUILD_DIR/conda-env.sh config --show
 end_section "info.conda.config"
 
 start_section "info.conda.package" "Info on ${YELLOW}conda package${NC}"
-./conda-env.sh render --no-source $CONDA_BUILD_ARGS || true
+$TRAVIS_BUILD_DIR/conda-env.sh render --no-source $CONDA_BUILD_ARGS || true
 end_section "info.conda.package"
 
 $SPACER
@@ -44,5 +44,5 @@ end_section "conda.copy"
 $SPACER
 
 start_section "conda.download" "${GREEN}Downloading..${NC}"
-./conda-env.sh build --source $CONDA_BUILD_ARGS || true
+$TRAVIS_BUILD_DIR/conda-env.sh build --source $CONDA_BUILD_ARGS || true
 end_section "conda.download"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -38,6 +38,7 @@ start_section "conda.copy" "${GREEN}Copying package...${NC}"
 mkdir -p /tmp/conda/$PACKAGE
 cp -vRL $PACKAGE/* /tmp/conda/$PACKAGE/
 cd /tmp/conda/
+sed -e"s@git_url:.*://@$CONDA_PATH/conda-bld/git_cache/@" -i /tmp/conda/$PACKAGE/meta.yaml
 end_section "conda.copy"
 
 $SPACER

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -6,25 +6,25 @@ set -e
 $SPACER
 
 start_section "info.conda.package" "Info on ${YELLOW}conda package${NC}"
-./conda-env.sh render $CONDA_BUILD_ARGS
+$TRAVIS_BUILD_DIR/conda-env.sh render $CONDA_BUILD_ARGS
 end_section "info.conda.package"
 
 $SPACER
 
 start_section "conda.check" "${GREEN}Checking...${NC}"
-./conda-env.sh build --check $CONDA_BUILD_ARGS || true
+$TRAVIS_BUILD_DIR/conda-env.sh build --check $CONDA_BUILD_ARGS || true
 end_section "conda.check"
 
 $SPACER
 
 start_section "conda.build" "${GREEN}Building..${NC}"
-$CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log ./conda-env.sh build $CONDA_BUILD_ARGS
+$CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log $TRAVIS_BUILD_DIR/conda-env.sh build $CONDA_BUILD_ARGS
 end_section "conda.build"
 
 $SPACER
 
 start_section "conda.build" "${GREEN}Installing..${NC}"
-./conda-env.sh install $CONDA_OUT
+$TRAVIS_BUILD_DIR/conda-env.sh install $CONDA_OUT
 end_section "conda.build"
 
 $SPACER

--- a/conda-tag-filter.sh
+++ b/conda-tag-filter.sh
@@ -7,7 +7,7 @@ PACKAGE=${1:-PACKAGE}
 TAG_EXTRACT='[0-9]+[_.][0-9]+([_.][0-9])?([._\-]rc[0-9]+)?([_\-][0-9]+[_\-]g[0-9a-fA-F]+)?$'
 TAG_PATTERN='^v[0-9]+\.[0-9]+(\.[0-9]+|\.rc[0-9]+)*$'
 
-CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | head -1 | sed -e's/.* //')
+for CONDA_GIT_URL in $(cat $PACKAGE/meta.yaml | grep "git_url" | sed -e's/.* //'); do
 CONDA_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$CONDA_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
 if [ ! -d $CONDA_GIT_DIR ]; then
 	git clone --bare "$CONDA_GIT_URL" $CONDA_GIT_DIR
@@ -86,3 +86,4 @@ fi
 	fi
 	echo "Git describe output: '$(git describe --tags)'"
 )
+done

--- a/conda-tag-filter.sh
+++ b/conda-tag-filter.sh
@@ -7,7 +7,7 @@ PACKAGE=${1:-PACKAGE}
 TAG_EXTRACT='[0-9]+[_.][0-9]+([_.][0-9])?([._\-]rc[0-9]+)?([_\-][0-9]+[_\-]g[0-9a-fA-F]+)?$'
 TAG_PATTERN='^v[0-9]+\.[0-9]+(\.[0-9]+|\.rc[0-9]+)*$'
 
-CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | awk '{print $2}')
+CONDA_GIT_URL=$(cat $PACKAGE/meta.yaml | grep "git_url" | head -1 | sed -e's/.* //')
 CONDA_GIT_DIR=$CONDA_PATH/conda-bld/git_cache/$(echo "$CONDA_GIT_URL" | grep -o '://.*' | cut -f3- -d/)
 if [ ! -d $CONDA_GIT_DIR ]; then
 	git clone --bare "$CONDA_GIT_URL" $CONDA_GIT_DIR

--- a/flterm/meta.yaml
+++ b/flterm/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or 'X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: flterm

--- a/iceprog/meta.yaml
+++ b/iceprog/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG or 'v0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: iceprog
   version: {{ version }}
 
 source:
-  git_url: https://github.com/mithro/icestorm.git
+  git_url: https://github.com/cliffordwolf/icestorm.git
   git_rev: master
   patches:
    - iceprog-only.patch

--- a/icestorm/meta.yaml
+++ b/icestorm/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: icestorm

--- a/iverilog/extra.tags
+++ b/iverilog/extra.tags
@@ -1,0 +1,1 @@
+v10.0.0 434bf0fe46e1fc13bf4ced569b11390fcfb7b66a

--- a/iverilog/meta.yaml
+++ b/iverilog/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG or 'sUNKNOWN', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: iverilog

--- a/moore/meta.yaml
+++ b/moore/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: moore
   version: {{ version }}

--- a/netlistsvg/meta.yaml
+++ b/netlistsvg/meta.yaml
@@ -1,11 +1,11 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('vpr-', '')|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: netlistsvg
   version: {{ version }}
 
 source:
-  git_url: https://github.com/mithro/netlistsvg.git
+  git_url: https://github.com/nturley/netlistsvg.git
   git_rev: master
 
 build:

--- a/odin_II/meta.yaml
+++ b/odin_II/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('vpr-', '')|replace('-v','.')|replace('-rc','_rc') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: odin_ii

--- a/openocd/meta.yaml
+++ b/openocd/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: openocd

--- a/sigrok-cli/meta.yaml
+++ b/sigrok-cli/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('sigrok-cli-', '')|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: sigrok-cli
   version: {{ version }}

--- a/slang/meta.yaml
+++ b/slang/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v',''), GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH) %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: slang
   version: {{ version }}

--- a/surelog/meta.yaml
+++ b/surelog/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: surelog
   version: {{ version }}

--- a/sv-parser/meta.yaml
+++ b/sv-parser/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: sv-parser
   version: {{ version }}

--- a/tree-sitter-verilog/meta.yaml
+++ b/tree-sitter-verilog/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: tree-sitter-verilog
   version: {{ version }}

--- a/verible/meta.yaml
+++ b/verible/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: verible
   version: {{ version }}

--- a/verilator/meta.yaml
+++ b/verilator/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s.0_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v', '') or '0.X.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: verilator

--- a/vtr/meta.yaml
+++ b/vtr/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('vpr-', '')|replace('-v','.')|replace('-rc','_rc') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: vtr

--- a/yosys-plugins/meta.yaml
+++ b/yosys-plugins/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('yosys-plugins-', '') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: yosys-plugins

--- a/yosys/meta.yaml
+++ b/yosys/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('yosys-', '') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
 
 package:
   name: yosys

--- a/zachjs-sv2v/meta.yaml
+++ b/zachjs-sv2v/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('-v','.') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
 package:
   name: zachjs-sv2v
   version: {{ version }}


### PR DESCRIPTION
The conda-tag-filter script now does the following;
 - Converts tags in custom form to a standard format.
 - Allows specifying custom extra tags.
 - Supports multiple git_url values.
 - Uses the local git cache after first download.
 - Understands rc and git-describe style versions.
 - Strips the v off the version string.

It really needs to be rewritten in Python as a `conda build prepare` command. See https://github.com/mithro/conda-build-prepare for an example starting point.