### PR TITLE
zachjs-sv2v: add NOTICE file

### DIFF
--- a/zachjs-sv2v/meta.yaml
+++ b/zachjs-sv2v/meta.yaml
@@ -27,5 +27,7 @@ test:
 about:
   home: https://github.com/zachjs/sv2v
   license: BSD
-  license_file: LICENSE
+  license_file:
+    - LICENSE
+    - NOTICE
   summary: 'sv2v converts SystemVerilog (IEEE 1800-2017) to Verilog (IEEE 1364-2005), with an emphasis on supporting synthesizable language constructs.'


### PR DESCRIPTION
The NOTICE file contains the licenses for sv2v's dependencies. I have not tested this myself, but I believe it is in line with the spec: https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html.