### PR TITLE
Add symbiflow-toolchain-xray metapackage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
   # protocol analyzers
   - PACKAGE=sigrok-cli
   - PACKAGE=yosys-plugins
+  # metapackages
+  - PACKAGE=symbiflow-toolchain-xray
 
 script:
   - bash $TRAVIS_BUILD_DIR/.travis/script.sh

--- a/symbiflow-toolchain-xray/condarc
+++ b/symbiflow-toolchain-xray/condarc
@@ -1,0 +1,3 @@
+channels:
+  - conda-forge
+  - symbiflow

--- a/symbiflow-toolchain-xray/meta.yaml
+++ b/symbiflow-toolchain-xray/meta.yaml
@@ -1,0 +1,27 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: symbiflow-toolchain-xray
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/conda-packages.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  run:
+    - vtr
+    - yosys
+    - yosys-plugins
+
+about:
+  summary: 'Conda metapackage combining VtR, Yosys and Yosys plugins.'


### PR DESCRIPTION
Changes introduce a conda metapackage that can be used to install bundled vtr, yosys and yosys-plugins. Since the metapackage does not have a git repository, versions can be generated from _conda-packages_ repository.

This approach gives user easier way to install tools with a single package `symbiflow-toolchain-xray`. To make sure it will install successfully follwing channels should be added to users conda environment:
- conda-forge
- symbiflow