### PR TITLE
symbiflow: add toolchain to conda channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ env:
   - PACKAGE=prjxray
   # XXX riscv32 toolchain: disabled as fails to build
   # PACKAGE=riscv32/binutils
+  # symbiflow toolchain
+  - PACKAGE=symbiflow-toolchain
+  - PACKAGE=symbiflow-xc7a50t
   # verilog tools
   - PACKAGE=icestorm
   - PACKAGE=iverilog

--- a/symbiflow-toolchain/build.sh
+++ b/symbiflow-toolchain/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/15/20200608-212841/symbiflow-arch-defs-install-32defbb3.tar.xz | tar -xJ
+
+BIN_DIR=${PREFIX}/bin
+SHARE_DIR=${PREFIX}/share/symbiflow
+
+mkdir -p $SHARE_DIR
+
+cp -r install/share/scripts $SHARE_DIR
+cp -r install/share/techmaps $SHARE_DIR
+cp -r install/bin/* $BIN_DIR/

--- a/symbiflow-toolchain/meta.yaml
+++ b/symbiflow-toolchain/meta.yaml
@@ -1,0 +1,21 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: symbiflow-toolchain
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/conda-packages.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+about:
+  summary: 'Conda package containing the Symbiflow binary toolchain.'

--- a/symbiflow-xc7a50t/build.sh
+++ b/symbiflow-xc7a50t/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+wget -qO- https://storage.googleapis.com/symbiflow-arch-defs/artifacts/prod/foss-fpga-tools/symbiflow-arch-defs/continuous/install/15/20200608-212841/symbiflow-arch-defs-install-32defbb3.tar.xz | tar -xJ
+
+SHARE_DIR=${PREFIX}/share/symbiflow
+
+mkdir -p $SHARE_DIR
+
+cp -r install/share/symbiflow/arch/xc7a50t_test $SHARE_DIR/arch/

--- a/symbiflow-xc7a50t/meta.yaml
+++ b/symbiflow-xc7a50t/meta.yaml
@@ -1,0 +1,21 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: symbiflow-xc7a50t
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/SymbiFlow/conda-packages.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+about:
+  summary: 'Conda package containing the xc7a50t architecture definition.'


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the symbiflow toolchain binaries to conda channels.

It also adds a separate package to get the architecture definitions for each device.
The only one that is present in this PR is the xc7a50t.

The idea is to have everything managed in conda, so that there is no need for an end-user to download the symbiflow toolchain using wget or similar, as well as changing the PATH env variable to point to the symbiflow binaries.