### PR TITLE
Use the bazel install target to install verible related tools.

### DIFF
--- a/verible/build.sh
+++ b/verible/build.sh
@@ -16,7 +16,5 @@ chmod +x bazel-0.29.1-installer-linux-x86_64.sh
 
 export PATH=$BAZEL_PREFIX/bin:$PATH
 
+bazel run :install -c opt -- $PREFIX/bin
 
-bazel build -c opt --cxxopt='-std=c++17' //...
-
-install -D bazel-bin/verilog/tools/syntax/verilog_syntax $PREFIX/bin/verilog_syntax


### PR DESCRIPTION
This will install not only verilog_syntax as it is now, but also
the linter and formatter. Even if not directly needed in our immediate
use-case (for sv-tests), it is useful to have these complete.

Signed-off-by: Henner Zeller <h.zeller@acm.org>