### PR TITLE
uhdm-integration: remove hellosureworld

### DIFF
--- a/uhdm-integration/surelog-flow.sh
+++ b/uhdm-integration/surelog-flow.sh
@@ -5,4 +5,3 @@ mkdir -p "$PREFIX/lib/surelog/sv"
 
 cp "$SRC_DIR/image/lib/surelog/sv/builtin.sv" "$PREFIX/lib/surelog/sv/builtin.sv"
 cp "$SRC_DIR/image/bin/surelog" "$PREFIX/bin/surelog-uhdm"
-cp "$SRC_DIR/Surelog/build/dist/Release/hellosureworld" "$PREFIX/bin/hellosureworld-uhdm"


### PR DESCRIPTION
The path of this application moved from `Surelog/build/dist/Release/` to
`Surelog/bin/` which broke the build.

However this is just a sample application which uses surelog as a
library. We don't need this binary in the conda package, therefore this
PR just removes it from the package.