### PR TITLE
Surelog cmake refers to python interpreter at build time, add to yaml.

### DIFF
--- a/surelog/meta.yaml
+++ b/surelog/meta.yaml
@@ -23,6 +23,8 @@ requirements:
     - pkg-config
     - python {{ python }}
     - gperftools
+    - libuuid
+    - swig
 
   host:
     - python {{ python }}

--- a/surelog/meta.yaml
+++ b/surelog/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - pkg-config
+    - python {{ python }}
+    - gperftools
 
   host:
     - python {{ python }}


### PR DESCRIPTION
This fixes #105

Signed-off-by: Henner Zeller <h.zeller@acm.org>