### PR TITLE
Clean up uhdm integration run dependencies

### DIFF
--- a/uhdm-integration/meta.yaml
+++ b/uhdm-integration/meta.yaml
@@ -32,7 +32,6 @@ outputs:
       requirements:
           run:
               - python {{ python }}
-              - readline ==8.0
               - gperftools
               - libunwind
       test:
@@ -42,10 +41,10 @@ outputs:
       script: verilator-flow.sh
       requirements:
           run:
-              - python {{ python }}
-              - readline ==8.0
-              - gperftools
-              - libunwind
+              - {{ compiler('cxx') }}
+              - bison
+              - flex
+              - ncurses
       test:
           commands:
               - verilator-uhdm --version
@@ -53,10 +52,7 @@ outputs:
       script: yosys-flow.sh
       requirements:
           run:
-              - python {{ python }}
-              - readline ==8.0
-              - gperftools
-              - libunwind
+              - readline
       test:
           commands:
               - yosys-uhdm --version


### PR DESCRIPTION
In attempt to fix dependency conflicts for https://github.com/SymbiFlow/sv-tests/pull/851

The actual dependency was `readline==8.0` while other packages (i.e Odin) require `readline <8`, but as the rest of the dependencies also seemed redundant this PR cleans up some of them too.