### PR TITLE
Remove Yosys dependency on readline for more robustness.

### DIFF
--- a/uhdm-integration/build.sh
+++ b/uhdm-integration/build.sh
@@ -14,4 +14,4 @@ export LDFLAGS="$CXXFLAGS -L$BUILD_PREFIX/lib -lrt -ltinfo"
 make -j$CPU_COUNT surelog/parse
 make -j$CPU_COUNT uhdm/build
 make -j$CPU_COUNT uhdm/verilator/build
-make -j$CPU_COUNT yosys/yosys
+make -j$CPU_COUNT ENABLE_READLINE=0 yosys/yosys

--- a/uhdm-integration/build.sh
+++ b/uhdm-integration/build.sh
@@ -15,3 +15,6 @@ make -j$CPU_COUNT surelog/parse
 make -j$CPU_COUNT uhdm/build
 make -j$CPU_COUNT uhdm/verilator/build
 make -j$CPU_COUNT ENABLE_READLINE=0 yosys/yosys
+
+# Mostly verifying that libreadline is indeed not linked
+ldd yosys/yosys

--- a/uhdm-integration/build.sh
+++ b/uhdm-integration/build.sh
@@ -16,5 +16,3 @@ make -j$CPU_COUNT uhdm/build
 make -j$CPU_COUNT uhdm/verilator/build
 make -j$CPU_COUNT ENABLE_READLINE=0 yosys/yosys
 
-# Mostly verifying that libreadline is indeed not linked
-ldd yosys/yosys

--- a/uhdm-integration/meta.yaml
+++ b/uhdm-integration/meta.yaml
@@ -50,6 +50,9 @@ outputs:
               - verilator-uhdm --version
     - name: yosys-uhdm
       script: yosys-flow.sh
+      requirements:
+          run:
+              - ncurses
       test:
           commands:
               - yosys-uhdm --version

--- a/uhdm-integration/meta.yaml
+++ b/uhdm-integration/meta.yaml
@@ -50,9 +50,6 @@ outputs:
               - verilator-uhdm --version
     - name: yosys-uhdm
       script: yosys-flow.sh
-      requirements:
-          run:
-              - readline
       test:
           commands:
               - yosys-uhdm --version


### PR DESCRIPTION
Context:
https://github.com/SymbiFlow/sv-tests/pull/851
https://github.com/SymbiFlow/conda-packages/pull/110

Signed-off-by: Henner Zeller <h.zeller@acm.org>