### PR TITLE
Remove readline from VTR and odin II

### DIFF
--- a/odin_II/meta.yaml
+++ b/odin_II/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - fontconfig
     - ncurses
     - pkg-config
-    - readline <8
     - tk
     - xorg-libice
     - xorg-libsm

--- a/symbiflow-vtr-gui/meta.yaml
+++ b/symbiflow-vtr-gui/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - fontconfig
     - ncurses
     - pkg-config
-    - readline <8
     - tk
     - xorg-libice
     - xorg-libsm
@@ -40,7 +39,6 @@ requirements:
     - tbb-devel
     - gtk3
   run:
-    - readline <8
     - tk
     - fontconfig
     - xorg-libx11


### PR DESCRIPTION
It appears that VTR has disable use of readline in abc, so it no longer has a readline dependency at all. 