### PR TITLE
Don't merge constants for yosys for the yosys conda package.

### DIFF
--- a/symbiflow-yosys/makefile-conda-config.patch
+++ b/symbiflow-yosys/makefile-conda-config.patch
@@ -9,7 +9,7 @@ index eb8f0f59..b1460a7a 100644
 +else ifeq ($(CONFIG),conda-linux)
 +CXX = x86_64-conda_cos6-linux-gnu-gcc
 +LD = x86_64-conda_cos6-linux-gnu-gcc
-+CXXFLAGS += -std=c++11 -Os
++CXXFLAGS += -std=c++11 -Os -fno-merge-constants
 +CFLAGS += -Wno-unused-function -Wno-unused-but-set-variable
 +ABCMKARGS += "ABC_READLINE_INCLUDES=-I${PREFIX}/include"
 +ABCMKARGS += "ABC_READLINE_LIBRARIES=-L${PREFIX}/lib -lreadline"


### PR DESCRIPTION
This is because some strings that get binary patched by the conda
installer might overlap with some internal strings used by yosys.

Without disabling merge-constants, the yosys share search path was
changing from `<binary path>/../share/yosys/` to `<binary path>/../share/` as
a result from conda stirng patching.