### PR TITLE
nextpnr: fix yosys dependencies

### DIFF
--- a/nextpnr-ice40/meta.yaml
+++ b/nextpnr-ice40/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - python {{ python }}
-    - yosys
+    - symbiflow-yosys
   host:
     - bison
     - boost
@@ -38,7 +38,7 @@ requirements:
     - libboost
     - py-boost
     - python
-    - yosys
+    - symbiflow-yosys
 
 test:
   commands:

--- a/nextpnr-xilinx/condarc
+++ b/nextpnr-xilinx/condarc
@@ -1,2 +1,0 @@
-channels:
-  - conda-forge

--- a/nextpnr-xilinx/meta.yaml
+++ b/nextpnr-xilinx/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python {{ python }}
     - libboost
     - py-boost
-    - yosys
+    - symbiflow-yosys
   host:
     - bison
     - boost
@@ -40,7 +40,7 @@ requirements:
     - libboost
     - py-boost
     - python
-    - yosys
+    - symbiflow-yosys
 
 test:
   commands:


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This solves a dependecy issue with the nextpnr packages. In fact, they depend on yosys, which switched to be symbiflow-yosys, therefore it would need to be modified in the nextpnr's meta.yml files as well.