### PR TITLE
prjxray-db: add script to bin that gets the db location

### DIFF
--- a/prjxray-db/build.sh
+++ b/prjxray-db/build.sh
@@ -15,3 +15,10 @@ mkdir -p $DBDIR
 for device in $DEVICES; do
     cp -r $device $DBDIR
 done
+
+mkdir -p $PREFIX/bin
+
+DB_CONFIG="${PREFIX}/bin/prjxray-config"
+
+echo -e "#!/bin/bash\n\necho ${DBDIR}" > ${DB_CONFIG}
+chmod +x ${DB_CONFIG}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds a bash script to the bin directory that can be used to retrieve the prjxray database location.