### PR TITLE
vtr: add capnp schemas location script

### DIFF
--- a/symbiflow-vtr-gui/build.sh
+++ b/symbiflow-vtr-gui/build.sh
@@ -47,3 +47,8 @@ make -j$CPU_COUNT install
 
 mkdir -p ${PREFIX}/lib
 mv ${PREFIX}/bin/*.a ${PREFIX}/lib/
+
+CAPNP_SCHEMAS=${PREFIX}/bin/capnp-schemas-dir
+
+echo -e "#!/bin/bash\n\necho ${PREFIX}/capnp" > ${CAPNP_SCHEMAS}
+chmod +x ${CAPNP_SCHEMAS}

--- a/symbiflow-vtr/build.sh
+++ b/symbiflow-vtr/build.sh
@@ -47,3 +47,8 @@ make -j$CPU_COUNT install
 
 mkdir -p ${PREFIX}/lib
 mv ${PREFIX}/bin/*.a ${PREFIX}/lib/
+
+CAPNP_SCHEMAS=${PREFIX}/bin/capnp-schemas-dir
+
+echo -e "#!/bin/bash\n\necho ${PREFIX}/capnp" > ${CAPNP_SCHEMAS}
+chmod +x ${CAPNP_SCHEMAS}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds a script in `CONDA_PREFIX/bin` to retrieve the capnp schemas directory location.