### PR TITLE
Add yosys fork capable of processing Ibex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
   - PACKAGE=libxml2
   - PACKAGE=libusb
   - PACKAGE=symbiflow-yosys
+  - PACKAGE=antmicro-yosys
   - PACKAGE=nextpnr-ice40
   - PACKAGE=nextpnr-xilinx
   - PACKAGE=openocd

--- a/antmicro-yosys/build.sh
+++ b/antmicro-yosys/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [ x"$TRAVIS" = xtrue ]; then
+	CPU_COUNT=2
+fi
+
+#unset CFLAGS
+#unset CXXFLAGS
+#unset CPPFLAGS
+#unset DEBUG_CXXFLAGS
+#unset DEBUG_CPPFLAGS
+#unset LDFLAGS
+
+which pkg-config
+
+cd yosys
+
+make V=1 -j$CPU_COUNT
+cp yosys "$PREFIX/bin/antmicro-yosys"
+
+$PREFIX/bin/antmicro-yosys -V

--- a/antmicro-yosys/condarc
+++ b/antmicro-yosys/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/antmicro-yosys/meta.yaml
+++ b/antmicro-yosys/meta.yaml
@@ -1,0 +1,31 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: antmicro-yosys
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/antmicro/ibex-yosys-build
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+  host:
+    - pkg-config
+    - readline
+    - bison
+    - tk
+    - libffi
+    - flex
+    - iverilog


### PR DESCRIPTION
This PR adds yosys from Antmicro fork to conda packages https://github.com/antmicro/yosys/tree/ibex-wip-symbiflow
This fork is able to process the whole Ibex design. We're adding this fork to conda packages to check its results with other cores in sv-tests.