### PR TITLE
yosys-plugins: Build params plugin

### DIFF
--- a/symbiflow-yosys-plugins/build.sh
+++ b/symbiflow-yosys-plugins/build.sh
@@ -13,4 +13,4 @@ echo "PREFIX := $PREFIX" >> Makefile.conf
 
 make -C fasm-plugin install -j$CPU_COUNT
 make -C xdc-plugin install -j$CPU_COUNT
-
+make -C params-plugin install -j$CPU_COUNT


### PR DESCRIPTION
Add a command to `build.sh` to build the params plugin shared object (params.so)