### PR TITLE
Bump GCC version for uhdm-integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
   - PACKAGE=surelog
   - PACKAGE=sv-parser
   - PACKAGE=verible             USE_SYSTEM_GCC_VERSION="8"
-  - PACKAGE=uhdm-integration
+  - PACKAGE=uhdm-integration    USE_SYSTEM_GCC_VERSION="9"
   # protocol analyzers
   - PACKAGE=sigrok-cli
   - PACKAGE=symbiflow-yosys-plugins


### PR DESCRIPTION
This PR is for testing if the `uhdm-integration` build passes with a newer version of GCC. Will mark as ready to merge if it passes.