### PR TITLE
yosys-plugins: Install all plugins with new SDC plugin

### DIFF
--- a/symbiflow-yosys-plugins/build.sh
+++ b/symbiflow-yosys-plugins/build.sh
@@ -11,7 +11,4 @@ which pkg-config
 
 echo "PREFIX := $PREFIX" >> Makefile.conf
 
-make -C fasm-plugin install -j$CPU_COUNT
-make -C xdc-plugin install -j$CPU_COUNT
-make -C params-plugin install -j$CPU_COUNT
-make -C selection-plugin install -j$CPU_COUNT
+make install -j$CPU_COUNT


### PR DESCRIPTION
Install all plugin using the dedicated install target that installs all plugins.
With this PR the SDC plugin will be built for the first time after it has been merged into yosys-symbiflow-plugins.