### PR TITLE
Relax symbiflow-yosys libffi version dependency

### DIFF
--- a/symbiflow-yosys/meta.yaml
+++ b/symbiflow-yosys/meta.yaml
@@ -28,13 +28,13 @@ requirements:
     - readline
     - bison
     - tk
-    - libffi
+    - libffi>=3.2.1
     - flex
     - iverilog
   run:
     - readline
     - tk
-    - libffi
+    - libffi>=3.2.1
 
 about:
   home: http://www.clifford.at/yosys/


### PR DESCRIPTION
Relaxed `sybmiflow-yosys` required `libffi` version to be >=3.2.1. Some packages (like `pygobject`) require `libffi` =3.3 which resulted in conflicts.