### PR TITLE
Separate symbiflow-yosys versions for different libffi version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ env:
   - PACKAGE=symbiflow-vtr
   - PACKAGE=libxml2
   - PACKAGE=libusb
-  - PACKAGE=symbiflow-yosys
+  - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.2.1
+  - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.3
   - PACKAGE=antmicro-yosys
   - PACKAGE=nextpnr-ice40
   - PACKAGE=nextpnr-xilinx

--- a/symbiflow-yosys/meta.yaml
+++ b/symbiflow-yosys/meta.yaml
@@ -1,4 +1,5 @@
 {% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+{% set build_string = '%s_libffi%s'|format(DATE_STR, LIBFFI_VERSION|replace('.', '')) %}
 
 package:
   name: symbiflow-yosys
@@ -13,8 +14,8 @@ source:
 build:
   # number: 201803050325
   number: {{ environ.get('DATE_NUM') }}
-  # string: 20180305_0325
-  string: {{ environ.get('DATE_STR') }}
+  # string: 20180305_0325_libffi321
+  string: {{ build_string }}
   script_env:
     - CI
     - TRAVIS
@@ -28,13 +29,13 @@ requirements:
     - readline
     - bison
     - tk
-    - libffi>=3.2.1
+    - libffi={{ environ.get('LIBFFI_VERSION') }}
     - flex
     - iverilog
   run:
     - readline
     - tk
-    - libffi>=3.2.1
+    - libffi={{ environ.get('LIBFFI_VERSION') }}
 
 about:
   home: http://www.clifford.at/yosys/


### PR DESCRIPTION
With https://github.com/SymbiFlow/conda-packages/pull/134 I broke `symbiflow-yosys` by allowing it to be built using `libffi` v3.3 and then requiring v3.2.1. To solve the problem of different `libffi` versions for good I made Travis build separate `symbiflow-yosys` packages for each of them.

I intend to do it in the same manner as it is done eg. for Python 3.8. There are two separate packages for different `libffi` versions that differ in the build string:
```
file name   : python-3.8.2-hcf32534_0.conda
  - libffi >=3.2.1,<3.3a0
file name   : python-3.8.2-hcff3b4d_13.conda
  - libffi >=3.3,<3.4.0a0
```

(These can be looked up via the command: `conda search python=3.8* --info | grep -E "file|libffi"`)