### PR TITLE
Add conda package for capnproto-java.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.2.1
   - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.3
   - PACKAGE=antmicro-yosys
+  - PACKAGE=capnproto-java
   - PACKAGE=nextpnr-ice40
   - PACKAGE=nextpnr-xilinx
   - PACKAGE=openocd

--- a/capnproto-java/build.sh
+++ b/capnproto-java/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+make all
+make install

--- a/capnproto-java/condarc
+++ b/capnproto-java/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/capnproto-java/meta.yaml
+++ b/capnproto-java/meta.yaml
@@ -1,0 +1,39 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: capnproto-java
+  version: {{ version }}
+
+source:
+  git_rev: master
+  git_url: https://github.com/capnproto/capnproto-java.git
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - capnproto
+    - pkg-config
+  host:
+    - capnproto
+    - pkg-config
+  run:
+    - capnproto
+
+#test:
+#  commands:
+#    - capnpc-java --help # [unix]
+#    - test -d "$PREFIX/include/capnp/java.capnp"  # [unix]
+
+about:
+  home: https://capnproto.org/
+  license: MIT
+  summary: "Cap'n Proto in pure Java"


### PR DESCRIPTION
This is required for https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1673 to supply java.capnp for pycapnp.