### PR TITLE
Pin yosys plugins to exact version due to sensitivity of packages.

### DIFF
--- a/symbiflow-yosys-plugins/meta.yaml
+++ b/symbiflow-yosys-plugins/meta.yaml
@@ -31,5 +31,5 @@ requirements:
     - iverilog
     - symbiflow-yosys
   run:
-    - symbiflow-yosys
+    - {{ pin_subpackage('symbiflow-yosys', exact=True) }}
 


### PR DESCRIPTION
I'm testing this hypothesis in another PR, but this arose in https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1674 