### PR TITLE
Add symbiflow-tools-package-manager package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
   - PACKAGE=openocd
   - PACKAGE=prjxray-tools
   - PACKAGE=prjxray-db
+  - PACKAGE=symbiflow-tools-package-manager
   # XXX riscv32 toolchain: disabled as fails to build
   # PACKAGE=riscv32/binutils
   # verilog tools

--- a/symbiflow-tools-package-manager/condarc
+++ b/symbiflow-tools-package-manager/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/symbiflow-tools-package-manager/meta.yaml
+++ b/symbiflow-tools-package-manager/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: symbiflow-tools-package-manager
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/symbiflow/symbiflow-tools-package-manager.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+  script: {{ PYTHON }} -m pip install . -vv
+
+requirements:
+  build:
+    - python {{ python }}
+    - pip
+  run:
+    - python {{ python }}
+    - requests
+
+test:
+  commands:
+    - symbiflow_get_latest_artifact_url
+
+about:
+  license: ISC
+  license_file: LICENSE
+  summary: 'Conda package containing STPM (SymbiFlow Tools Package Manager) binaries.'


### PR DESCRIPTION
The package just installs `get_latest_artifact_url` binary which can be called from command line.

Here is the status in Travis when built from [initial-release branch](https://github.com/antmicro/symbiflow-tools-package-manager/tree/initial-release): https://travis-ci.com/github/antmicro/conda-packages/jobs/401965186

NOTE: a tag should be added to https://github.com/SymbiFlow/symbiflow-tools-package-manager to make `git describe` step work.
NOTE 2: this PR can be merged after https://github.com/SymbiFlow/symbiflow-tools-package-manager/pull/1