### PR TITLE
uhdm-integration build fix

### DIFF
--- a/uhdm-integration/build.sh
+++ b/uhdm-integration/build.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 if [ x"$TRAVIS" = xtrue ]; then
-	CPU_COUNT=2
+	CPU_COUNT=$(nproc)
 fi
 
 export PKG_CONFIG_PATH="$BUILD_PREFIX/lib/pkgconfig/"
@@ -15,4 +15,3 @@ make -j$CPU_COUNT surelog/parse
 make -j$CPU_COUNT uhdm/build
 make -j$CPU_COUNT uhdm/verilator/build
 make -j$CPU_COUNT ENABLE_READLINE=0 yosys/yosys
-

--- a/uhdm-integration/build.sh
+++ b/uhdm-integration/build.sh
@@ -12,6 +12,4 @@ export CXXFLAGS="$CXXFLAGS -I$BUILD_PREFIX/include"
 export LDFLAGS="$CXXFLAGS -L$BUILD_PREFIX/lib -lrt -ltinfo"
 
 make -j$CPU_COUNT surelog/parse
-make -j$CPU_COUNT uhdm/build
-make -j$CPU_COUNT uhdm/verilator/build
-make -j$CPU_COUNT ENABLE_READLINE=0 yosys/yosys
+make -j$CPU_COUNT prep


### PR DESCRIPTION
This PR is for fixing CI build errors on `uhdm-integration`.  I changed the `CPU_COUNT` to be max available on given machine and replaced make targets to match changes in uhdm.