### PR TITLE
rearrange antmicro-yosys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - PACKAGE=libusb
   - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.2.1
   - PACKAGE=symbiflow-yosys     LIBFFI_VERSION=3.3
-  - PACKAGE=antmicro-yosys
+  - PACKAGE=antmicro-yosys-complete
   - PACKAGE=capnproto
   - PACKAGE=capnproto-java
   - PACKAGE=nextpnr-ice40

--- a/antmicro-yosys-complete/condarc
+++ b/antmicro-yosys-complete/condarc
@@ -1,0 +1,3 @@
+channels:
+  - conda-forge
+  - symbiflow

--- a/antmicro-yosys-complete/meta.yaml
+++ b/antmicro-yosys-complete/meta.yaml
@@ -1,0 +1,16 @@
+{% set version = '%s_%04i_%s'|format(GIT_DESCRIBE_TAG|replace('v','') or '0.X', GIT_DESCRIBE_NUMBER|int, GIT_DESCRIBE_HASH or 'gUNKNOWN') %}
+
+package:
+  name: antmicro-yosys-complete
+  version: {{ version }}
+
+source:
+  git_url: https://github.com/antmicro/ibex-yosys-build.git
+  git_rev: master
+
+requirements:
+  run:
+    - antmicro-yosys-plugins
+
+about:
+  summary: 'Conda metapackage combining Antmicro Yosys fork and Yosys plugins.'

--- a/antmicro-yosys-plugins/build.sh
+++ b/antmicro-yosys-plugins/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+CPU_COUNT=$(nproc)
+
+which pkg-config
+
+echo "PREFIX := $PREFIX" >> Makefile.conf
+
+cd yosys-symbiflow-plugins
+make install -j$CPU_COUNT

--- a/antmicro-yosys-plugins/condarc
+++ b/antmicro-yosys-plugins/condarc
@@ -1,0 +1,2 @@
+channels:
+  - conda-forge

--- a/antmicro-yosys-plugins/meta.yaml
+++ b/antmicro-yosys-plugins/meta.yaml
@@ -1,0 +1,29 @@
+package:
+  name: antmicro-yosys-plugins
+  version: 0.0
+
+source:
+  git_url: https://github.com/antmicro/ibex-yosys-build.git
+  git_rev: master
+
+build:
+  # number: 201803050325
+  number: {{ environ.get('DATE_NUM') }}
+  # string: 20180305_0325
+  string: {{ environ.get('DATE_STR') }}
+  script_env:
+    - CI
+    - TRAVIS
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - antmicro-yosys
+    - make
+  host:
+    - iverilog
+    - antmicro-yosys
+  run:
+    - antmicro-yosys
+

--- a/antmicro-yosys/build.sh
+++ b/antmicro-yosys/build.sh
@@ -3,9 +3,7 @@
 set -e
 set -x
 
-if [ x"$TRAVIS" = xtrue ]; then
-	CPU_COUNT=2
-fi
+CPU_COUNT=$(nproc)
 
 #unset CFLAGS
 #unset CXXFLAGS
@@ -19,6 +17,8 @@ which pkg-config
 cd yosys
 
 make V=1 -j$CPU_COUNT
+make install V=1 -j$CPU_COUNT
 cp yosys "$PREFIX/bin/antmicro-yosys"
+cp yosys-config "$PREFIX/bin/yosys-config"
 
 $PREFIX/bin/antmicro-yosys -V

--- a/antmicro-yosys/meta.yaml
+++ b/antmicro-yosys/meta.yaml
@@ -21,6 +21,8 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - make
+    - gawk
   host:
     - pkg-config
     - readline
@@ -29,3 +31,11 @@ requirements:
     - libffi
     - flex
     - iverilog
+  run:
+    - readline
+    - tk
+    - libffi
+
+test:
+  commands:
+    - antmicro-yosys -V


### PR DESCRIPTION
This PR is rearranging Antmicro Yosys fork package. We added separate plugins package and bundled it together with yosys in metapackage `antmicro-yosys-complete`. These changes allow removing explicit dependency `symbiflow-yosys-plugins` from each CI job in `sv-tests`.