### PR TITLE
Start adding support for potential aarch64 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Miniconda3-latest-Linux-x86_64.sh
+Miniconda3-latest-Linux-aarch64.sh
 recipe_append.yaml

--- a/conda-get.sh
+++ b/conda-get.sh
@@ -4,13 +4,22 @@ set -e
 
 CONDA_PATH=${1:-~/conda}
 
-echo "Downloading Conda installer."
-wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-chmod a+x Miniconda3-latest-Linux-x86_64.sh
+case $(uname -m) in
+i386|x86_64)
+	export HOST_ARCH="x86_64"
+;;
+arm64|aarch64)
+	export HOST_ARCH="aarch64"
+;;
+esac
+
+echo "Downloading Conda installer for ${HOST_ARCH}."
+wget -c https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-${HOST_ARCH}.sh
+chmod a+x Miniconda3-latest-Linux-${HOST_ARCH}.sh
 
 if [ ! -d $CONDA_PATH ]; then
 	echo "Installing conda"
-        ./Miniconda3-latest-Linux-x86_64.sh -p $CONDA_PATH -b -f
+        ./Miniconda3-latest-Linux-${HOST_ARCH}.sh -p $CONDA_PATH -b -f
 fi
 export PATH=$CONDA_PATH/bin:$PATH
 

--- a/iceprog/build.sh
+++ b/iceprog/build.sh
@@ -14,12 +14,22 @@ unset DEBUG_CXXFLAGS
 unset DEBUG_CPPFLAGS
 unset LDFLAGS
 
-INCLUDES="$(PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig pkg-config --dont-define-prefix --cflags libftdi1 libusb libudev)"
+
+case $(uname -m) in
+i386|x86_64)
+	export HOST_ARCH="x86_64"
+;;
+arm64|aarch64)
+	export HOST_ARCH="aarch64"
+;;
+esac
+
+INCLUDES="$(PKG_CONFIG_PATH=/usr/lib/${HOST_ARCH}-linux-gnu/pkgconfig pkg-config --dont-define-prefix --cflags libftdi1 libusb libudev)"
 INCLUDES='-I/usr/include/libftdi1 -I/usr/include/libusb-1.0'
-STATIC_LIBS="$(PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig pkg-config --dont-define-prefix --libs libftdi1 libusb)"
-STATIC_LIBS="-L/usr/lib/x86_64-linux-gnu -lftdi1 -lusb-1.0 -lusb"
-DYNAMIC_LIBS="$(PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig pkg-config --dont-define-prefix --libs libudev)"
-DYNAMIC_LIBS="-L/lib/x86_64-linux-gnu -ludev"
+STATIC_LIBS="$(PKG_CONFIG_PATH=/usr/lib/${HOST_ARCH}-linux-gnu/pkgconfig pkg-config --dont-define-prefix --libs libftdi1 libusb)"
+STATIC_LIBS="-L/usr/lib/${HOST_ARCH}-linux-gnu -lftdi1 -lusb-1.0 -lusb"
+DYNAMIC_LIBS="$(PKG_CONFIG_PATH=/usr/lib/${HOST_ARCH}-linux-gnu/pkgconfig pkg-config --dont-define-prefix --libs libudev)"
+DYNAMIC_LIBS="-L/lib/${HOST_ARCH}-linux-gnu -ludev"
 
 export CFLAGS="$CFLAGS $INCLUDES"
 export LDFLAGS="$LDFLAGS -lm -lstdc++ -lpthread -Wl,--whole-archive -Wl,-Bstatic $STATIC_LIBS -Wl,-Bdynamic -Wl,--no-whole-archive $DYNAMIC_LIBS"

--- a/verible/build.sh
+++ b/verible/build.sh
@@ -3,6 +3,15 @@
 set -e
 set -x
 
+case $(uname -m) in
+i386|x86_64)
+	export HOST_ARCH="x86_64"
+;;
+arm64|aarch64)
+	export HOST_ARCH="aarch64"
+;;
+esac
+
 export CC=gcc-${USE_SYSTEM_GCC_VERSION}
 export CXX=g++-${USE_SYSTEM_GCC_VERSION}
 
@@ -10,9 +19,10 @@ export CXX=g++-${USE_SYSTEM_GCC_VERSION}
 mkdir bazel-install
 BAZEL_PREFIX=$PWD/bazel-install
 
-wget https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-installer-linux-x86_64.sh
-chmod +x bazel-3.7.2-installer-linux-x86_64.sh
-./bazel-3.7.2-installer-linux-x86_64.sh --prefix=$BAZEL_PREFIX
+
+wget https://github.com/bazelbuild/bazel/releases/download/3.7.2/bazel-3.7.2-installer-linux-${HOST_ARCH}.sh
+chmod +x bazel-3.7.2-installer-linux-${HOST_ARCH}.sh
+./bazel-3.7.2-installer-linux-${HOST_ARCH}.sh --prefix=$BAZEL_PREFIX
 
 export PATH=$BAZEL_PREFIX/bin:$PATH
 


### PR DESCRIPTION
Hi,

This PR brings what's needed in this repository to start to have some support for a potential aarch64 build for symbiflow.

This does not mean that symbiflow now supports aarch64, far from it, but since symbiflow is all of these hardwired gits, better to start somewhere.

Here we just add some switch case testing for which arch we are running on and fills the ressources name for it. 

Of course, remarks welcome!

Alexis Marquet